### PR TITLE
Adding a Convolutional Autoencoder and a Variational Autoencoder (VAE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Linear or original Dense network based autoencoder is the primary autoencoder wh
 
 ##### How to use it?
 Download this repo and go inside it. Then 
-
+Basic Autoencoder Usage
 ```Python 
 from model import AutoEncoder, Sparse_Autoencoder
 from dataset import mnist_dataset
@@ -51,7 +51,72 @@ model = load_model(model_class, model_path, device, **model_kwargs)
 infer_and_visualize(model, loader, device)
 
 ````
+Convolutional Autoencoder Usage
+```Python
+from model import Conv_Autoencoder
+from dataset import mnist_dataset
+from torch import nn, optim
+import torch
+from train import train_conv_autoencoder
 
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+loader = mnist_dataset(batch_size=32)
+
+model = Conv_Autoencoder(input_dim=784, latent_dim=32)
+loss_fn = nn.MSELoss()
+optimizer = optim.Adam(model.parameters(), lr=1e-3, weight_decay=1e-8)
+epochs = 20
+
+train_conv_autoencoder(model, loader, loss_fn, optimizer, epochs, device)
+````
+````python
+from model import AutoEncoder, Sparse_Autoencoder,VAE,Conv_Autoencoder
+from dataset import mnist_dataset
+from inference import load_model, infer_and_visualize
+import torch
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+loader = mnist_dataset(batch_size=32, train=False)
+
+model_class = Conv_Autoencoder
+model_path = "Conv_Autoencoder.pth"
+model_kwargs = dict(input_dim=784, latent_dim=32)
+
+model = load_model(model_class, model_path, device, **model_kwargs)
+infer_and_visualize(model, loader, device)
+````
+Variational Autoencoder (VAE) Usage
+````python
+from model import VAE
+from dataset import mnist_dataset
+import torch
+from train import train_vae
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+loader = mnist_dataset(batch_size=32)
+
+model = VAE(input_dim=784, latent_dim=64, beta=8.0).to(device)
+optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4, weight_decay=1e-5)
+epochs = 20
+
+train_vae(model, loader, optimizer, epochs=epochs, device=device)
+````
+````python
+from model import AutoEncoder, Sparse_Autoencoder,VAE,Conv_Autoencoder
+from dataset import mnist_dataset
+from inference import load_model, infer_and_visualize
+import torch
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+loader = mnist_dataset(batch_size=32, train=False)
+
+model_class = VAE
+model_path = "vae.pth"
+model_kwargs = dict(input_dim=784, latent_dim=64)
+
+model = load_model(model_class, model_path, device, **model_kwargs)
+infer_and_visualize(model, loader, device)
+````
 #### Trained model
 We also provide our trained models in the model folder called **autoencoder.pth** and sparse_autoencoder.pth
 
@@ -59,7 +124,7 @@ We also provide our trained models in the model folder called **autoencoder.pth*
 
 - [x] Include Sparse Autoencoder
 - [ ] Include Variational Autoencoder (VAE)
-- [ ] Include Convolutional Autoencoder
+- [x] Include Convolutional Autoencoder
 - [x] Refactor into high-level wrapper / framework
 - [ ] Increase architectural difficulty and depth
 - [ ] Add multi-GPU training support

--- a/model.py
+++ b/model.py
@@ -250,3 +250,203 @@ class VQE_AutoEncoder(nn.Module):
         x_recon = self._decoder(quantized)
 
         return loss, x_recon, perplexity
+
+class VAE(nn.Module):
+    def __init__(self, input_dim, latent_dim, beta=8.0):  # Set beta to 8. A smaller beta value will make KLD particularly small
+        """
+        Variational Autoencoder (VAE) implementation with enhanced architecture.
+        Uses KL divergence weighting (β-VAE) for better latent space organization.
+        
+        Args:
+            input_dim (int): Dimension of input data
+            latent_dim (int): Dimension of latent space representation
+            beta (float): Weight for KL divergence term (default: 8.0)
+                          Higher values encourage more disentangled latent representations
+        """
+        super().__init__()
+        self.input_dim = input_dim
+        self.latent_dim = latent_dim
+        self.beta = beta # β parameter for β-VAE formulation
+
+        # Enhanced encoder network with layer normalization
+        self.encoder = nn.Sequential(
+            nn.Linear(input_dim, 512),
+            nn.LeakyReLU(0.2),# LeakyReLU helps prevent dead neurons
+            nn.Linear(512, 256),
+            nn.LayerNorm(256),# LayerNorm stabilizes training
+            nn.LeakyReLU(0.2),
+            nn.Linear(256, 128),
+            nn.LayerNorm(128),
+            nn.LeakyReLU(0.2)
+        )
+        
+        # Latent spatial parameter layer
+        self.fc_mu = nn.Linear(128, latent_dim)# Mean of latent distribution
+        self.fc_var = nn.Linear(128, latent_dim) # Log variance of latent distribution
+        
+        # Initialization
+        nn.init.constant_(self.fc_var.bias, 0.0)  # Initialize log_var near 0 (σ≈1)
+        nn.init.normal_(self.fc_var.weight, mean=0, std=0.001)# Small weights
+        nn.init.constant_(self.fc_mu.bias, 0.0)# Zero bias for mean
+        nn.init.normal_(self.fc_mu.weight, mean=0, std=0.001)# Small weights
+
+        # Enhanced decoder network with layer normalization
+        self.decoder = nn.Sequential(
+            nn.Linear(latent_dim, 128),
+            nn.LayerNorm(128),
+            nn.LeakyReLU(0.2),
+            nn.Linear(128, 256),
+            nn.LayerNorm(256),
+            nn.LeakyReLU(0.2),
+            nn.Linear(256, 512),
+            nn.LayerNorm(512),
+            nn.LeakyReLU(0.2),
+            nn.Linear(512, input_dim),
+            nn.Sigmoid()# Output values between 0-1 for reconstruction
+        )
+
+    def encode(self, x):
+        """
+        Encodes input into parameters of latent distribution.
+        
+        Args:
+            x: Input tensor of shape [batch_size, input_dim]
+            
+        Returns:
+            mu: Mean of latent distribution
+            log_var: Log variance of latent distribution
+        """
+        h = self.encoder(x.view(-1, self.input_dim))
+        return self.fc_mu(h), self.fc_var(h)
+
+    def reparameterize(self, mu, log_var):
+        """
+        Reparameterization trick to enable backpropagation through sampling.
+        Includes enhanced noise intensity for better exploration.
+        
+        Args:
+            mu: Mean of latent distribution
+            log_var: Log variance of latent distribution
+            
+        Returns:
+            Sampled latent vector with reparameterization
+        """
+        std = torch.exp(0.5 * log_var.clamp(min=-10, max=2))  # Constrained σ between (0.006,2.718)
+        eps = torch.randn_like(std) * 1.2  # Enhanced noise multiplier (1.2x)
+        return mu + eps * std
+
+    def forward(self, x, epoch=None):
+        """
+        Forward pass of the VAE.
+        
+        Args:
+            x: Input tensor of shape [batch_size, input_dim]
+            epoch: Optional epoch number (unused in this implementation)
+            
+        Returns:
+            During training: Tuple of (reconstruction, mu, log_var)
+            Otherwise: Just reconstruction
+        """
+        mu, log_var = self.encode(x)
+        z = self.reparameterize(mu, log_var)
+        return self.decoder(z).view_as(x) if not self.training else (self.decoder(z).view_as(x), mu, log_var)
+
+    def loss_function(self, recon_x, x, mu, log_var):
+        """
+        Computes VAE loss = reconstruction loss + β*KL divergence.
+        Includes additional constraint on latent mean for regularization.
+        
+        Args:
+            recon_x: Reconstructed input
+            x: Original input
+            mu: Mean of latent distribution
+            log_var: Log variance of latent distribution
+            
+        Returns:
+            Total loss averaged over batch
+        """
+        # Binary cross-entropy reconstruction loss
+        BCE = F.binary_cross_entropy(recon_x, x, reduction='sum')
+        
+        # Enhanced KL divergence with additional mean constraint
+        KLD = -0.5 * torch.sum(1 + log_var - mu.pow(2) - log_var.exp())
+        KLD += 0.5 * torch.mean(mu.pow(2))  # Additional constraint on mean
+        # Weighted combination with β factor
+        return (BCE + self.beta * KLD) / x.size(0)# Average over batch
+class Conv_Autoencoder(nn.Module):
+    def __init__(self, input_dim, latent_dim):
+        """
+        Convolutional Autoencoder implementation for image data.
+        
+        Args:
+            input_dim (int): Total dimension of flattened input (img_size * img_size)
+            latent_dim (int): Dimension of the bottleneck latent representation
+        """
+        super().__init__()
+        self.input_dim = input_dim
+        self.img_size = int(input_dim**0.5)  # Calculate original image size (assuming square)
+        
+        # Encoder network: Compresses input image into latent representation
+        self.encoder = nn.Sequential(
+            # Reshape flattened input into image format (batch, channel, height, width)
+            nn.Unflatten(1, (1, self.img_size, self.img_size)),  # [B,1,28,28] for MNIST
+            
+            # First convolutional block (halves spatial dimensions)
+            nn.Conv2d(1, 16, kernel_size=3, stride=2, padding=1),  # [B,16,14,14]
+            nn.ReLU(),
+            
+            # Second convolutional block (halves spatial dimensions again)
+            nn.Conv2d(16, 32, kernel_size=3, stride=2, padding=1),  # [B,32,7,7]
+            nn.ReLU(),
+            
+            # Flatten before dense layers
+            nn.Flatten(),
+            
+            # First fully-connected layer
+            nn.Linear(32*7*7, 256),  # 32*7*7=1568 for MNIST
+            nn.ReLU(),
+            
+            # Final projection to latent space
+            nn.Linear(256, latent_dim)
+        )
+        
+        # Decoder network: Reconstructs image from latent representation
+        self.decoder = nn.Sequential(
+            # Expand latent vector
+            nn.Linear(latent_dim, 256),
+            nn.ReLU(),
+            
+            # Project to conv transpose input size
+            nn.Linear(256, 32*7*7),  # Matching encoder's last conv output shape
+            nn.ReLU(),
+            
+            # Reshape for convolutional transpose operations
+            nn.Unflatten(1, (32, 7, 7)),  # [B,32,7,7]
+            
+            # First transposed convolution block (doubles spatial dimensions)
+            nn.ConvTranspose2d(32, 16, kernel_size=3, stride=2, 
+                              padding=1, output_padding=1),  # [B,16,14,14]
+            nn.ReLU(),
+            
+            # Second transposed convolution block (doubles spatial dimensions)
+            nn.ConvTranspose2d(16, 1, kernel_size=3, stride=2, 
+                              padding=1, output_padding=1),  # [B,1,28,28]
+            nn.Sigmoid(),  # Pixel values between 0-1
+            
+            # Flatten output to match input format
+            nn.Flatten()
+        )
+
+    def forward(self, x):
+        """
+        Forward pass of the autoencoder.
+        
+        Args:
+            x: Flattened input tensor of shape [batch_size, input_dim]
+            
+        Returns:
+            Reconstructed output tensor of same shape as input
+        """
+        encoded = self.encoder(x)  # Encode to latent space
+        decoded = self.decoder(encoded)  # Reconstruct from latent space
+        return decoded


### PR DESCRIPTION
I added a Convolutional Autoencoder and a Variational Autoencoder (VAE). I followed the previous code structure and only added code on this basis. I have trained these two new models and taken screenshots of their results. After modifying these files, I ran the previous two models (Sparse Autoencoder and Autoencoder) again and recorded their performances. Finally, I revised the readme document and added the code required for the new model to run. The following are the changes I have made
I added two new training functions to the file. model.py
2. I added two loss functions that the new model will use in the file. train.py
3. I added the code needed to run the new model in the file. readme.md
4. I added the necessary comments for all the new code
5.My updated code didn't break existing structure. No monoliths were made and dataset was being called neatly from file.  dataset.py

Explanation of the performance of the new model:
The performance of the Convolutional Autoencoder is better than that of previous models. The loss at the 20th Epoch is around 0.004, and it can regenerate almost perfect black-and-white images.
The performance of Variational Autoencoder is somewhat poor. In fact, when the standard VAE model was initially used, a Mode Collapse occurred, and all the generated images were the same. Therefore, I increased the value of beta to 8, used a deeper network, switched to BCE loss, and enhanced the KL constraint. Now the model can reconstruct the image to a certain extent (although some numbers are still confused).