### PR TITLE
Add and fix:VAE and Conv

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Linear or original Dense network based autoencoder is the primary autoencoder wh
 
 ##### How to use it?
 Download this repo and go inside it. Then 
+Basic Autoencoder Usage
 
 ```Python 
 from model import AutoEncoder, Sparse_Autoencoder
@@ -51,6 +52,80 @@ model = load_model(model_class, model_path, device, **model_kwargs)
 infer_and_visualize(model, loader, device)
 
 ````
+Convolutional Autoencoder Usage
+```Python
+from model import AutoEncoder, Sparse_Autoencoder,VAE,Conv_Autoencoder
+from dataset import mnist_dataset
+from torch import nn, optim
+import torch
+from train import train_model
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+loader = mnist_dataset(batch_size=32)
+
+model = Conv_Autoencoder(input_dim=784, latent_dim=32).to(device)
+
+if isinstance(model, Sparse_Autoencoder):
+    loss_fn = model.sparse_loss
+else:
+    loss_fn = nn.MSELoss()
+
+optimizer = optim.Adam(model.parameters(), lr=1e-3, weight_decay=1e-8)
+epochs = 20
+
+train_model(model, loader,loss_fn,optimizer, epochs, device)
+````
+````python
+from model import AutoEncoder, Sparse_Autoencoder,VAE,Conv_Autoencoder
+from dataset import mnist_dataset
+from inference import load_model, infer_and_visualize
+import torch
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+loader = mnist_dataset(batch_size=32, train=False)
+
+model_class = Conv_Autoencoder
+model_path = "Conv_Autoencoder.pth"
+model_kwargs = dict(input_dim=784, latent_dim=32)
+
+model = load_model(model_class, model_path, device, **model_kwargs)
+infer_and_visualize(model, loader, device)
+````
+Variational Autoencoder (VAE) Usage
+````python
+from model import VAE
+from dataset import mnist_dataset
+from torch import nn, optim
+import torch
+from train import train_model
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+loader = mnist_dataset(batch_size=32)
+
+model = VAE(input_dim=784, latent_dim=64, beta=8.0).to(device)
+
+loss_fn = model.calculate_loss# Directly use the loss calculation method within the model
+
+optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4, weight_decay=1e-5)
+epochs = 20
+train_model(model, loader, loss_fn, optimizer, epochs, device)
+````
+````python
+from model import VAE
+from dataset import mnist_dataset
+from inference import load_model, infer_and_visualize
+import torch
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+loader = mnist_dataset(batch_size=32, train=False)
+
+model_class = VAE
+model_path = "vae.pth"
+model_kwargs = dict(input_dim=784, latent_dim=64)
+
+model = load_model(model_class, model_path, device, **model_kwargs)
+infer_and_visualize(model, loader, device)
+````
 
 #### Trained model
 We also provide our trained models in the model folder called **autoencoder.pth** and sparse_autoencoder.pth
@@ -58,8 +133,8 @@ We also provide our trained models in the model folder called **autoencoder.pth*
 ## Upcoming Autoencoder Enhancements
 
 - [x] Include Sparse Autoencoder
-- [ ] Include Variational Autoencoder (VAE)
-- [ ] Include Convolutional Autoencoder
+- [x] Include Variational Autoencoder (VAE)
+- [x] Include Convolutional Autoencoder
 - [x] Refactor into high-level wrapper / framework
 - [ ] Increase architectural difficulty and depth
 - [ ] Add multi-GPU training support

--- a/model.py
+++ b/model.py
@@ -55,4 +55,400 @@ class Sparse_Autoencoder(nn.Module):
         kl_div = torch.sum(kl)
         return mse_loss + self.lambda_sparse * kl_div
 
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+
+
+class VectorQuantizerEMA(nn.Module):
+    def __init__(self, num_embeddings, embedding_dim, commitment_cost, decay, epsilon=1e-5):
+        super().__init__()
         
+        self._embedding_dim = embedding_dim
+        self._num_embeddings = num_embeddings
+        
+        self._embedding = nn.Embedding(self._num_embeddings, self._embedding_dim)
+        self._embedding.weight.data.normal_()
+        self._commitment_cost = commitment_cost
+        
+        self.register_buffer('_ema_cluster_size', torch.zeros(num_embeddings))
+        self._ema_w = nn.Parameter(torch.Tensor(num_embeddings, self._embedding_dim))
+        self._ema_w.data.normal_()
+        
+        self._decay = decay
+        self._epsilon = epsilon
+
+    def forward(self, inputs):
+        # convert inputs from BCHW -> BHWC
+        inputs = inputs.permute(0, 2, 3, 1).contiguous()
+        input_shape = inputs.shape
+        
+        # Flatten input
+        flat_input = inputs.view(-1, self._embedding_dim)
+        
+        # Calculate distances
+        distances = (torch.sum(flat_input**2, dim=1, keepdim=True) 
+                    + torch.sum(self._embedding.weight**2, dim=1)
+                    - 2 * torch.matmul(flat_input, self._embedding.weight.t()))
+            
+        # Encoding
+        encoding_indices = torch.argmin(distances, dim=1).unsqueeze(1)
+        encodings = torch.zeros(encoding_indices.shape[0], self._num_embeddings, device=inputs.device)
+        encodings.scatter_(1, encoding_indices, 1)
+        
+        # Quantize and unflatten
+        quantized = torch.matmul(encodings, self._embedding.weight).view(input_shape)
+        
+        # Use EMA to update the embedding vectors
+        if self.training:
+            self._ema_cluster_size = self._ema_cluster_size * self._decay + \
+                                     (1 - self._decay) * torch.sum(encodings, 0)
+            
+            # Laplace smoothing of the cluster size
+            n = torch.sum(self._ema_cluster_size.data)
+            self._ema_cluster_size = (
+                (self._ema_cluster_size + self._epsilon)
+                / (n + self._num_embeddings * self._epsilon) * n)
+            
+            dw = torch.matmul(encodings.t(), flat_input)
+            self._ema_w = nn.Parameter(self._ema_w * self._decay + (1 - self._decay) * dw)
+            
+            self._embedding.weight = nn.Parameter(self._ema_w / self._ema_cluster_size.unsqueeze(1))
+        
+        # Loss
+        e_latent_loss = F.mse_loss(quantized.detach(), inputs)
+        loss = self._commitment_cost * e_latent_loss
+        
+        # Straight Through Estimator
+        quantized = inputs + (quantized - inputs).detach()
+        avg_probs = torch.mean(encodings, dim=0)
+        perplexity = torch.exp(-torch.sum(avg_probs * torch.log(avg_probs + 1e-10)))
+        
+        # convert quantized from BHWC -> BCHW
+        return loss, quantized.permute(0, 3, 1, 2).contiguous(), perplexity, encodings
+    
+class Residual(nn.Module):
+    def __init__(self, in_channels, num_hiddens, num_residual_hiddens):
+        super().__init__()
+        self._block = nn.Sequential(
+            nn.ReLU(True),
+            nn.Conv2d(in_channels=in_channels,
+                      out_channels=num_residual_hiddens,
+                      kernel_size=3, stride=1, padding=1, bias=False),
+            nn.ReLU(True),
+            nn.Conv2d(in_channels=num_residual_hiddens,
+                      out_channels=num_hiddens,
+                      kernel_size=1, stride=1, bias=False)
+        )
+    
+    def forward(self, x):
+        return x + self._block(x)
+
+
+class ResidualStack(nn.Module):
+    def __init__(self, in_channels, num_hiddens, num_residual_layers, num_residual_hiddens):
+        super().__init__()
+        self._num_residual_layers = num_residual_layers
+        self._layers = nn.ModuleList([Residual(in_channels, num_hiddens, num_residual_hiddens)
+                             for _ in range(self._num_residual_layers)])
+
+    def forward(self, x):
+        for i in range(self._num_residual_layers):
+            x = self._layers[i](x)
+        return F.relu(x)
+    
+class Encoder(nn.Module):
+    def __init__(self, in_channels, num_hiddens, num_residual_layers, num_residual_hiddens):
+        super().__init__()
+
+        self._conv_1 = nn.Conv2d(in_channels=in_channels,
+                                 out_channels=num_hiddens//2,
+                                 kernel_size=4,
+                                 stride=2, padding=1)
+        self._conv_2 = nn.Conv2d(in_channels=num_hiddens//2,
+                                 out_channels=num_hiddens,
+                                 kernel_size=4,
+                                 stride=2, padding=1)
+        self._conv_3 = nn.Conv2d(in_channels=num_hiddens,
+                                 out_channels=num_hiddens,
+                                 kernel_size=3,
+                                 stride=1, padding=1)
+        self._residual_stack = ResidualStack(in_channels=num_hiddens,
+                                             num_hiddens=num_hiddens,
+                                             num_residual_layers=num_residual_layers,
+                                             num_residual_hiddens=num_residual_hiddens)
+
+    def forward(self, inputs):
+        x = self._conv_1(inputs)
+        x = F.relu(x)
+        
+        x = self._conv_2(x)
+        x = F.relu(x)
+        
+        x = self._conv_3(x)
+        return self._residual_stack(x)
+    
+class Decoder(nn.Module):
+    def __init__(self, in_channels, num_hiddens, num_residual_layers, num_residual_hiddens):
+        super().__init__()
+        
+        self._conv_1 = nn.Conv2d(in_channels=in_channels,
+                                 out_channels=num_hiddens,
+                                 kernel_size=3, 
+                                 stride=1, padding=1)
+        
+        self._residual_stack = ResidualStack(in_channels=num_hiddens,
+                                             num_hiddens=num_hiddens,
+                                             num_residual_layers=num_residual_layers,
+                                             num_residual_hiddens=num_residual_hiddens)
+        
+        self._conv_trans_1 = nn.ConvTranspose2d(in_channels=num_hiddens, 
+                                                out_channels=num_hiddens//2,
+                                                kernel_size=4, 
+                                                stride=2, padding=1)
+        
+        self._conv_trans_2 = nn.ConvTranspose2d(in_channels=num_hiddens//2, 
+                                                out_channels=3,
+                                                kernel_size=4, 
+                                                stride=2, padding=1)
+
+    def forward(self, inputs):
+        x = self._conv_1(inputs)
+        
+        x = self._residual_stack(x)
+        
+        x = self._conv_trans_1(x)
+        x = F.relu(x)
+        
+        return self._conv_trans_2(x)
+    
+class VQE_AutoEncoder(nn.Module):
+    def __init__(self, num_hiddens, num_residual_layers, num_residual_hiddens, 
+                 num_embeddings, embedding_dim, commitment_cost, decay=0):
+        super().__init__()
+        
+        self._encoder = Encoder(3, num_hiddens,
+                                num_residual_layers, 
+                                num_residual_hiddens)
+        self._pre_vq_conv = nn.Conv2d(in_channels=num_hiddens, 
+                                      out_channels=embedding_dim,
+                                      kernel_size=1, 
+                                      stride=1)
+        if decay > 0.0:
+            self._vq_vae = VectorQuantizerEMA(num_embeddings, embedding_dim, 
+                                              commitment_cost, decay)
+        self._decoder = Decoder(embedding_dim,
+                                num_hiddens, 
+                                num_residual_layers, 
+                                num_residual_hiddens)
+
+    def forward(self, x):
+        z = self._encoder(x)
+        z = self._pre_vq_conv(z)
+        loss, quantized, perplexity, _ = self._vq_vae(z)
+        x_recon = self._decoder(quantized)
+
+        return loss, x_recon, perplexity
+class VAE(nn.Module):
+    def __init__(self, input_dim, latent_dim, beta=3.0):  # Set beta to 3. 
+        """
+        Variational Autoencoder (VAE) implementation with enhanced architecture.
+        Uses KL divergence weighting (β-VAE) for better latent space organization.
+        
+        Args:
+            input_dim (int): Dimension of input data
+            latent_dim (int): Dimension of latent space representation
+            beta (float): Weight for KL divergence term (default: 3.0)
+                          Higher values encourage more disentangled latent representations
+        """
+        super().__init__()
+        self.input_dim = input_dim
+        self.latent_dim = latent_dim
+        self.beta = beta # β parameter for β-VAE formulation
+
+        # Enhanced encoder network with layer normalization
+        self.encoder = nn.Sequential(
+            nn.Linear(input_dim, 512),
+            nn.LeakyReLU(0.2),# LeakyReLU helps prevent dead neurons
+            nn.Linear(512, 256),
+            nn.LayerNorm(256),# LayerNorm stabilizes training
+            nn.LeakyReLU(0.2),
+            nn.Linear(256, 128),
+            nn.LayerNorm(128),
+            nn.LeakyReLU(0.2)
+        )
+        
+        # Latent spatial parameter layer
+        self.fc_mu = nn.Linear(128, latent_dim)# Mean of latent distribution
+        self.fc_var = nn.Linear(128, latent_dim) # Log variance of latent distribution
+        
+        # Initialization
+        nn.init.constant_(self.fc_var.bias, 0.0)  # Initialize log_var near 0 (σ≈1)
+        nn.init.normal_(self.fc_var.weight, mean=0, std=0.001)# Small weights
+        nn.init.constant_(self.fc_mu.bias, 0.0)# Zero bias for mean
+        nn.init.normal_(self.fc_mu.weight, mean=0, std=0.001)# Small weights
+
+        # Enhanced decoder network with layer normalization
+        self.decoder = nn.Sequential(
+            nn.Linear(latent_dim, 128),
+            nn.LayerNorm(128),
+            nn.LeakyReLU(0.2),
+            nn.Linear(128, 256),
+            nn.LayerNorm(256),
+            nn.LeakyReLU(0.2),
+            nn.Linear(256, 512),
+            nn.LayerNorm(512),
+            nn.LeakyReLU(0.2),
+            nn.Linear(512, input_dim),
+            nn.Sigmoid()# Output values between 0-1 for reconstruction
+        )
+
+    def encode(self, x):
+        """
+        Encodes input into parameters of latent distribution.
+        
+        Args:
+            x: Input tensor of shape [batch_size, input_dim]
+            
+        Returns:
+            mu: Mean of latent distribution
+            log_var: Log variance of latent distribution
+        """
+        h = self.encoder(x.view(-1, self.input_dim))
+        return self.fc_mu(h), self.fc_var(h)
+
+    def reparameterize(self, mu, log_var):
+        """
+        Reparameterization trick to enable backpropagation through sampling.
+        Includes enhanced noise intensity for better exploration.
+        
+        Args:
+            mu: Mean of latent distribution
+            log_var: Log variance of latent distribution
+            
+        Returns:
+            Sampled latent vector with reparameterization
+        """
+        std = torch.exp(0.5 * log_var.clamp(min=-10, max=2))  # Constrained σ between (0.006,2.718)
+        eps = torch.randn_like(std) * 1.2  # Standard normal noise
+        return mu + eps * std
+
+    def forward(self, x, epoch=None):
+        """
+        Forward pass of the VAE.
+        
+        Args:
+            x: Input tensor of shape [batch_size, input_dim]
+            epoch: Optional epoch number (unused in this implementation)
+            
+        Returns:
+            During training: Tuple of (reconstruction, mu, log_var)
+            Otherwise: Just reconstruction
+        """
+        mu, log_var = self.encode(x)
+        z = self.reparameterize(mu, log_var)
+        recon = self.decoder(z).view_as(x)
+        
+        return recon
+    
+    def calculate_loss(self, recon_x, x,current_step=None):
+        """
+        Calculate the total loss of VAE (BCE + β*KLD)For external training function calls
+        """
+        mu, log_var = self.encode(x)
+        # Binary cross-entropy reconstruction loss
+        mse_loss = F.mse_loss(recon_x, x, reduction='sum')# Sum of MSE loss over all elements
+        bce_loss = F.binary_cross_entropy(recon_x, x, reduction='sum')# Sum of BCE loss over all elements
+        recon_loss = 0.7*bce_loss + 0.3*mse_loss  # Weighted mixture of reconstruction losses
+        # Enhanced KL divergence with additional mean constraint
+        KLD = -0.5 * torch.mean(1 + log_var - mu.pow(2) - log_var.exp())   # Additional constraint on mean
+        # Dynamic beta annealing
+        if current_step is not None:
+            annealing_factor = min(current_step/10000, 1.0)  # 10,000 steps of linear growth
+            effective_beta = self.beta * annealing_factor
+        else:
+            effective_beta = self.beta
+        
+        return recon_loss + effective_beta * KLD
+        
+class Conv_Autoencoder(nn.Module):
+    def __init__(self, input_dim, latent_dim):
+        """
+        Convolutional Autoencoder implementation for image data.
+        
+        Args:
+            input_dim (int): Total dimension of flattened input (img_size * img_size)
+            latent_dim (int): Dimension of the bottleneck latent representation
+        """
+        super().__init__()
+        self.input_dim = input_dim
+        self.img_size = int(input_dim**0.5)  # Calculate original image size (assuming square)
+        
+        # Encoder network: Compresses input image into latent representation
+        self.encoder = nn.Sequential(
+            # Reshape flattened input into image format (batch, channel, height, width)
+            nn.Unflatten(1, (1, self.img_size, self.img_size)),  # [B,1,28,28] for MNIST
+            
+            # First convolutional block (halves spatial dimensions)
+            nn.Conv2d(1, 16, kernel_size=3, stride=2, padding=1),  # [B,16,14,14]
+            nn.ReLU(),
+            
+            # Second convolutional block (halves spatial dimensions again)
+            nn.Conv2d(16, 32, kernel_size=3, stride=2, padding=1),  # [B,32,7,7]
+            nn.ReLU(),
+            
+            # Flatten before dense layers
+            nn.Flatten(),
+            
+            # First fully-connected layer
+            nn.Linear(32*7*7, 256),  # 32*7*7=1568 for MNIST
+            nn.ReLU(),
+            
+            # Final projection to latent space
+            nn.Linear(256, latent_dim)
+        )
+        
+        # Decoder network: Reconstructs image from latent representation
+        self.decoder = nn.Sequential(
+            # Expand latent vector
+            nn.Linear(latent_dim, 256),
+            nn.ReLU(),
+            
+            # Project to conv transpose input size
+            nn.Linear(256, 32*7*7),  # Matching encoder's last conv output shape
+            nn.ReLU(),
+            
+            # Reshape for convolutional transpose operations
+            nn.Unflatten(1, (32, 7, 7)),  # [B,32,7,7]
+            
+            # First transposed convolution block (doubles spatial dimensions)
+            nn.ConvTranspose2d(32, 16, kernel_size=3, stride=2, 
+                              padding=1, output_padding=1),  # [B,16,14,14]
+            nn.ReLU(),
+            
+            # Second transposed convolution block (doubles spatial dimensions)
+            nn.ConvTranspose2d(16, 1, kernel_size=3, stride=2, 
+                              padding=1, output_padding=1),  # [B,1,28,28]
+            nn.Sigmoid(),  # Pixel values between 0-1
+            
+            # Flatten output to match input format
+            nn.Flatten()
+        )
+
+    def forward(self, x):
+        """
+        Forward pass of the autoencoder.
+        
+        Args:
+            x: Flattened input tensor of shape [batch_size, input_dim]
+            
+        Returns:
+            Reconstructed output tensor of same shape as input
+        """
+        encoded = self.encoder(x)  # Encode to latent space
+        decoded = self.decoder(encoded)  # Reconstruct from latent space
+        return decoded
+    def calculate_loss(self,output,target):
+        """calculate MSE loss for the autoencoder"""
+        return F.mse_loss(output,target)


### PR DESCRIPTION
I added a Convolutional Autoencoder and a Variational Autoencoder (VAE). I followed the previous code structure and only  added code on this basis. I have trained these two new models and taken screenshots of their results. After modifying  these files,  I ran the previous two models (Sparse Autoencoder and Autoencoder) again and recorded their performances. Finally,  I revised the readme document and added the code required for the new model to run. The following are the changes I have  made
1.I added two new training functions to the file and ensure model-specific loss calculations into the model class .  model.py
2. I added the code needed to run the new model in the file. readme.md
3. I added the necessary comments for all the new code
4.My updated code didn't break existing structure. No monoliths were made and dataset was being called neatly from file.  dataset.py

Explanation of the performance of the new model:
The performance of the Convolutional Autoencoder is better than that of previous models. The loss at the 20th Epoch is  around 0.004, and it can regenerate almost perfect black-and-white images.
The performance of Variational Autoencoder is somewhat looks good.  We see that he has over a thousand losses because I used sum to calculate the loss function (calculating the sum of losses for each epoch instead of the average, as I found that using mean would cause Mode Collapse). So, compared with other models, his losses are not that large, and he still performs well.